### PR TITLE
fix: escaping of cf cli params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2024-07-02
+
+### Fixed
+
+- Adjustments of ui texts
+- Escaping for Org name, Space name and SSO passcode
+
 ## [1.4.0] - 2024-05-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "btpcflogin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "btpcflogin",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "os": [
         "linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btpcflogin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Easy login to SAP BTP Cloud Foundry (cf cli)",
   "author": "Marcus Schölzel <marcus.schoelzel@gmx.de>",
   "repository": {

--- a/src/util/cf-cli.ts
+++ b/src/util/cf-cli.ts
@@ -103,7 +103,8 @@ export class CloudFoundryCli {
   setSpace(cfSpace: string) {
     const spaceProgress = ora("Switching space, please wait...").start();
     try {
-      checkSpawnErrors(spawnSync("cf", ["target", "-s", cfSpace]));
+      // HINT: Special characters in space name are possible but are not escapable (e.g. '"', '$')
+      checkSpawnErrors(spawnSync("cf", ["target", "-s", `"${cfSpace}"`]));
     } finally {
       spaceProgress.stop();
     }
@@ -124,7 +125,7 @@ export class CloudFoundryCli {
   setOrg(orgName: string) {
     const orgProgress = ora("Switching organisation, please wait...").start();
     try {
-      checkSpawnErrors(spawnSync("cf", ["target", "-o", orgName]));
+      checkSpawnErrors(spawnSync("cf", ["target", "-o", `"${orgName}"`]));
     } finally {
       orgProgress.stop();
     }

--- a/src/util/cf-cli.ts
+++ b/src/util/cf-cli.ts
@@ -44,6 +44,10 @@ function checkSpawnErrors(spawnResult: SpawnSyncReturns<Buffer>) {
   }
 }
 
+/**
+ * Surrounds given value in double quotes and replaces characters
+ * depending on platform
+ */
 function escapePassword(val: string) {
   if (process.platform === "win32") {
     // Escapes '"' character


### PR DESCRIPTION
Escapes sso code, org name and space name before passing them  to the CF cli