### PR TITLE
feat: enhancements to favorite handling/commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2024-11-23
+
+### Added
+
+- Existing favorites can now be overwritten when login command is executed with `-s`
+- Favorites can be renamed with new command `rename-fav`
+
+### Fixed
+
+- Removing a favorite, added enquirer properties in the `favoriteTargits` array of `btpcflogin`'s config store file
+
 ## [1.4.1] - 2024-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removing a favorite, added enquirer properties in the `favoriteTargits` array of `btpcflogin`'s config store file
+- Removing a favorite added enquirer properties in the `favoriteTargits` array of `btpcflogin`'s config store file
 
 ## [1.4.1] - 2024-07-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btpcflogin",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Easy login to SAP BTP Cloud Foundry (cf cli)",
   "author": "Marcus Schölzel <marcus.schoelzel@gmx.de>",
   "repository": {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,6 +7,7 @@ import { spawnSync } from "child_process";
 import { SSO_LOGIN_KEY, ConfigStoreProxy } from "../util/config-store.js";
 import { CloudFoundryCli } from "../util/cf-cli.js";
 import { assertCmdInPath } from "../util/helper.js";
+import { mapToPromptChoices } from "../util/favorites.js";
 
 export class LoginFlow {
   private cfCli: CloudFoundryCli;
@@ -97,10 +98,7 @@ export class LoginFlow {
       type: "autocomplete",
       name: "favoriteName",
       message: "Choose Favorite for SAP BTP CF Login",
-      choices: favorites.map((f) => ({
-        name: f.name,
-        hint: `Region: ${f.region}, Org: ${f.org}, Space: ${f.space}${f.sso ? `, Login: ${f.passLogin}` : ""}`,
-      })),
+      choices: mapToPromptChoices(favorites),
     });
 
     const favorite = favorites.find((f) => f.name === favoriteName)!;

--- a/src/commands/remove-favorite.ts
+++ b/src/commands/remove-favorite.ts
@@ -1,6 +1,7 @@
 import Enquirer from "enquirer";
 import { ConfigStoreProxy } from "../util/config-store.js";
 import chalk from "chalk";
+import { mapToPromptChoices } from "../util/favorites.js";
 
 export async function removeFavorite() {
   const configStore = new ConfigStoreProxy();
@@ -16,7 +17,7 @@ export async function removeFavorite() {
       type: "autocomplete",
       name: "favToRemove",
       message: "Select favorite to remove",
-      choices: storedFavorites,
+      choices: mapToPromptChoices(storedFavorites),
     });
 
     storedFavorites.splice(

--- a/src/commands/rename-favorite.ts
+++ b/src/commands/rename-favorite.ts
@@ -1,0 +1,51 @@
+import Enquirer from "enquirer";
+import { ConfigStoreProxy } from "../util/config-store.js";
+import chalk from "chalk";
+import { mapToPromptChoices } from "../util/favorites.js";
+
+export async function renameFavorite() {
+  const configStore = new ConfigStoreProxy();
+
+  try {
+    const storedFavorites = configStore.getFavorites();
+    if (!storedFavorites.length) {
+      console.error(chalk.yellow("No Favorites in Configstore!"));
+      return;
+    }
+
+    const { favToEdit } = await Enquirer.prompt<{ favToEdit: string }>({
+      type: "autocomplete",
+      name: "favToEdit",
+      message: "Select favorite to rename",
+      choices: mapToPromptChoices(storedFavorites),
+    });
+
+    const favorite = storedFavorites.find((f) => f.name === favToEdit)!;
+
+    favorite.name = await promptForNewName(
+      favorite.name,
+      storedFavorites.filter((f) => f.name !== favToEdit).map((f) => f.name),
+    );
+
+    configStore.setFavorites(storedFavorites);
+  } catch (error) {
+    console.error(chalk.redBright(error));
+  }
+}
+
+async function promptForNewName(name: string, existingNames: string[]): Promise<string> {
+  const { newName } = await Enquirer.prompt<{ newName: string }>({
+    type: "input",
+    name: "newName",
+    message: "Enter new name",
+    validate(value) {
+      if (value === name) {
+        return `Favorite is already named '${value}'`;
+      } else if (existingNames.includes(value)) {
+        return "Favorite with same name already exists";
+      }
+      return true;
+    },
+  });
+  return newName;
+}

--- a/src/commands/sort-favorites.ts
+++ b/src/commands/sort-favorites.ts
@@ -1,6 +1,7 @@
 import Enquirer from "enquirer";
-import { ConfigStoreProxy, Favorite } from "../util/config-store.js";
+import { ConfigStoreProxy } from "../util/config-store.js";
 import chalk from "chalk";
+import { Favorite } from "../util/favorites.js";
 
 export async function sortFavorites() {
   const configStore = new ConfigStoreProxy();

--- a/src/commands/sort-favorites.ts
+++ b/src/commands/sort-favorites.ts
@@ -1,7 +1,7 @@
 import Enquirer from "enquirer";
 import { ConfigStoreProxy } from "../util/config-store.js";
 import chalk from "chalk";
-import { Favorite } from "../util/favorites.js";
+import { Favorite, mapToPromptChoices } from "../util/favorites.js";
 
 export async function sortFavorites() {
   const configStore = new ConfigStoreProxy();
@@ -22,7 +22,7 @@ export async function sortFavorites() {
       type: "sort",
       name: "sortedFavNames",
       message: "Reorder Favorites",
-      choices: storedFavorites.map((f) => f.name),
+      choices: mapToPromptChoices(storedFavorites),
     } as any);
 
     const sortedFavorites: Favorite[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { removeLogin } from "./commands/remove-login.js";
 import { sortLogins } from "./commands/sort-logins.js";
 import { removeFavorite } from "./commands/remove-favorite.js";
 import { sortFavorites } from "./commands/sort-favorites.js";
+import { renameFavorite } from "./commands/rename-favorite.js";
 
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(getDirname(import.meta.url), "..", "package.json"), {
@@ -40,6 +41,11 @@ program
   .command("sort-favs")
   .description("Sort the stored favorites in the configstore")
   .action(() => sortFavorites());
+
+program
+  .command("rename-fav")
+  .description("Rename a stored favorite in the configstore")
+  .action(() => renameFavorite());
 
 program
   .command("t")

--- a/src/util/config-store.ts
+++ b/src/util/config-store.ts
@@ -1,5 +1,5 @@
 import Configstore from "configstore";
-import z from "zod";
+import { Favorite, favoritesSchema } from "./favorites.js";
 
 const STORE_NAME = "btpcflogin";
 const PASS_LOGINS_STORE_KEY = "passLogins";
@@ -9,18 +9,6 @@ export const DEFAULT_IDP = "Default IdP";
 export const SSO_LOGIN_KEY = "single-sign-on";
 
 type Logins = string[];
-
-const favoriteSchema = z.object({
-  name: z.string(),
-  region: z.string(),
-  org: z.string(),
-  space: z.string(),
-  sso: z.boolean(),
-  passLogin: z.string().optional(),
-});
-const favoritesSchema = favoriteSchema.array().optional();
-
-export type Favorite = z.infer<typeof favoriteSchema>;
 
 export class ConfigStoreProxy {
   private config: Configstore;

--- a/src/util/config-store.ts
+++ b/src/util/config-store.ts
@@ -69,14 +69,21 @@ export class ConfigStoreProxy {
     }
   }
 
-  addFavorite(favorite: Favorite) {
+  addFavorite(favorite: Favorite, overwrite = false) {
     const favorites = this.getFavorites();
 
-    if (favorites.findIndex((f) => f.name === favorite.name) !== -1) {
-      throw new Error(`A favorite cf target with name '${favorite.name} already exists!`);
+    const existingIndex = favorites.findIndex((f) => f.name === favorite.name);
+    if (existingIndex !== -1) {
+      if (overwrite) {
+        favorites[existingIndex] = favorite;
+      } else {
+        throw new Error(`A favorite cf target with name '${favorite.name} already exists!`);
+      }
+    } else {
+      favorites.push(favorite);
     }
 
-    this.config.set(FAVORITE_TARGETS, [...favorites, favorite]);
+    this.config.set(FAVORITE_TARGETS, favorites);
   }
 
   setFavorites(favorites: Favorite[]) {

--- a/src/util/favorites.ts
+++ b/src/util/favorites.ts
@@ -11,3 +11,10 @@ const favoriteSchema = z.object({
 export const favoritesSchema = favoriteSchema.array().optional();
 
 export type Favorite = z.infer<typeof favoriteSchema>;
+
+export function mapToPromptChoices(favorites: Favorite[]) {
+  return favorites.map((f) => ({
+    name: f.name,
+    hint: `Region: ${f.region}, Org: ${f.org}, Space: ${f.space}${f.sso ? `, Login: ${f.passLogin}` : ""}`,
+  }));
+}

--- a/src/util/favorites.ts
+++ b/src/util/favorites.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+
+const favoriteSchema = z.object({
+  name: z.string(),
+  region: z.string(),
+  org: z.string(),
+  space: z.string(),
+  sso: z.boolean(),
+  passLogin: z.string().optional(),
+});
+export const favoritesSchema = favoriteSchema.array().optional();
+
+export type Favorite = z.infer<typeof favoriteSchema>;


### PR DESCRIPTION
Makes several enhancements to favorites:

- new command `rename-fav` to allow renaming of existing favorite
- existing favorites can be overwritten during `btpcflogin [login] -s`
- favorites listed as choices in enquirer prompts are always listed with details (org, space, region, ...)